### PR TITLE
Added GitHub workflow to build and test Go code.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,89 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Build and Test
+
+on: ["push"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1.19", "1.20"]
+    env:
+      GOPRIVATE: github.com/ServiceWeaver/weaver
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.version }}
+          cache: true
+
+      - name: Register weaver deploy key
+        uses: webfactory/ssh-agent@v0.7.0
+        with:
+          ssh-private-key: ${{ secrets.WEAVER_DEPLOY_KEY }}
+
+      - name: Configure git for private modules
+        run: git config --global url."ssh://git@github.com".insteadOf "https://github.com"
+
+      - name: Cache linter
+        uses: actions/cache@v3
+        with:
+          path: ~/go/bin/golangci-lint
+          key: golangci-lint-v1.51.0
+
+      - name: Cache protoc-gen-go
+        uses: actions/cache@v3
+        with:
+          path: ~/go/bin/protoc-gen-go
+          key: protoc-gen-go-v1.26
+
+      - name: Install linter
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.0
+
+      - name: Install protoc
+        run: sudo apt install -y protobuf-compiler
+
+      - name: Install protoc-gen-go
+        run: go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.26
+
+      - name: Install weaver
+        run: go install github.com/ServiceWeaver/weaver/cmd/weaver@latest
+
+      - name: Tidy
+        run: go mod tidy
+
+      - name: Generate
+        run: go generate -v ./...
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Vet
+        run: go vet -v ./...
+
+      - name: Lint
+        run: golangci-lint run ./...
+
+      - name: Test
+        run: go test -v ./...
+
+      - name: Test Race
+        run: go test -v -race ./...

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,23 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+linters:
+  disable:
+    - errcheck # Currently too many places are ignoring errors
+linters-settings:
+  staticcheck:
+    checks:
+      - all
+      - '-SA9003' # Flags empty else{}, which is sometimes useful for a comment.
+      - '-SA1019' # disable noisy deprecated API checks; TODO: fix and re-enable

--- a/dev/protoc.sh
+++ b/dev/protoc.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ServiceWeaver/weaver-gke
 
-go 1.20
+go 1.19
 
 require (
 	cloud.google.com/go/artifactregistry v1.10.0


### PR DESCRIPTION
This PR adds a GitHub workflow to build and test the Go code. See [this GitHub pull request][1] for a similar PR.

## Accessing Private Repos

The trickiest part of getting this workflow working was allowing the weaver-gke repo to access the private weaver repo. To get this to work, we generate an RSA key pair called a [deploy key][4]. A deploy key is a lot the SSH keys you use personally to authenticate with GitHub but it's for a machine instead of a person.

After creating the key pair, we upload the public key to the weaver repo and the private key as a secret to the weaver-gke repo. In the GitHub workflow, we ssh-add the private key and set GOPRIVATE appropriately to access the weaver repo.

See [2] and [3] for more information on this process.

## Details

- I decreased the go.mod version from go 1.20 to 1.19 since the code works with go 1.19.
- I converted protoc.sh to use bash instead of sh to make the script work with GitHub actions.
- I added a .golangci.yaml lint config to make the linter work.

[1]: https://github.com/ServiceWeaver/weaver/pull/2
[2]: https://zerokspot.com/weblog/2022/11/18/private-go-modules-on-github/
[3]: https://github.com/marketplace/actions/webfactory-ssh-agent
[4]: https://docs.github.com/en/developers/overview/managing-deploy-keys