### PR TITLE
Renamed log fields to align with slog.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	cloud.google.com/go/logging v1.6.1
 	cloud.google.com/go/monitoring v1.12.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.11.0
-	github.com/ServiceWeaver/weaver v0.0.1
+	github.com/ServiceWeaver/weaver v0.0.2
 	github.com/golang/protobuf v1.5.2
 	github.com/google/cel-go v0.13.0
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.11.
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.35.0 h1:6KWug9hBDdc7s9a0BxnxtTXPwFcLpVx7IUKO1SLIaDE=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.35.0 h1:vjtrvX7B3S+uqTIOvOUfqsMCa3eEtEOOQWm7ERI1pxg=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.35.0/go.mod h1:H785fvlgotVZqht+1rHhXSs8EJ8uPVmpBYkTYO3ccpc=
-github.com/ServiceWeaver/weaver v0.0.1 h1:biVZ6GbQ5bt5jbo8yMNTExJT1KXveCMtaoHM5UasEvY=
-github.com/ServiceWeaver/weaver v0.0.1/go.mod h1:cKA/Cv/zRVYOsV5KJjwy3puWB/qlWcDzJnACK1Q973E=
+github.com/ServiceWeaver/weaver v0.0.2 h1:VnGYJpaFWj/u8H/SWkP/GRGdKRLoWSFU4HCGDqTAaew=
+github.com/ServiceWeaver/weaver v0.0.2/go.mod h1:cKA/Cv/zRVYOsV5KJjwy3puWB/qlWcDzJnACK1Q973E=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/internal/gke/logging_test.go
+++ b/internal/gke/logging_test.go
@@ -26,20 +26,17 @@ func TestTranslate(t *testing.T) {
 		want    string
 		hasTime bool
 	}{
-		{`payload == "todo"`, `(textPayload="todo")`, false},
+		{`msg == "todo"`, `(textPayload="todo")`, false},
 		{`version == "v1"`, `(labels."serviceweaver/version"="v1")`, false},
 		{`full_version == "v1"`, `(labels."serviceweaver/full_version"="v1")`, false},
 		{`app == "todo"`, `(labels."serviceweaver/app"="todo")`, false},
 		{`app != "todo"`, `(labels."serviceweaver/app"!="todo")`, false},
-		{`line < 1`, `(labels."serviceweaver/line"<1)`, false},
-		{`line <= 1`, `(labels."serviceweaver/line"<=1)`, false},
-		{`line > 1`, `(labels."serviceweaver/line">1)`, false},
-		{`line >= 1`, `(labels."serviceweaver/line">=1)`, false},
 		{`app.contains("todo")`, `(labels."serviceweaver/app":"todo")`, false},
 		{`app.matches("todo")`, `(labels."serviceweaver/app"=~"todo")`, false},
 		{`attrs["name"] == "foo"`, `(labels."name"="foo")`, false},
 		{`attrs["name"].contains("foo")`, `(labels."name":"foo")`, false},
 		{`"foo" in attrs`, `(labels."foo":"")`, false},
+		{`source.contains("foo")`, `(labels."serviceweaver/source":"foo")`, false},
 		{`time < timestamp("1972-01-01T10:00:20Z")`, `(timestamp<"1972-01-01T10:00:20Z")`, true},
 		{`app == "todo" && component == "a"`, `((labels."serviceweaver/app"="todo") AND (labels."serviceweaver/component"="a"))`, false},
 		{`app == "todo" || app == "collatz"`, `((labels."serviceweaver/app"="todo") OR (labels."serviceweaver/app"="collatz"))`, false},


### PR DESCRIPTION
This PR updates the gke and gke-local deployers to be compatible with the change in [PR #19 on the main weaver repository][1].

[1]: https://github.com/ServiceWeaver/weaver/pull/19