### PR TITLE
Fixed GKE logging bug.

### DIFF
--- a/internal/gke/logging.go
+++ b/internal/gke/logging.go
@@ -588,6 +588,8 @@ func labelsFromEntry(entry *protos.LogEntry, meta *ContainerMetadata) map[string
 	ls["serviceweaver/full_component"] = entry.Component
 	ls["serviceweaver/time"] = time.UnixMicro(entry.TimeMicros).Format(time.RFC3339)
 	ls["serviceweaver/level"] = entry.Level
+	ls["serviceweaver/file"] = entry.File
+	ls["serviceweaver/line"] = fmt.Sprintf("%d", entry.Line)
 	ls["serviceweaver/source"] = fmt.Sprintf("%s:%d", entry.File, entry.Line)
 
 	return ls
@@ -611,6 +613,7 @@ func entryFromLabels(labels map[string]string) (*protos.LogEntry, error) {
 	ex("serviceweaver/version")
 	ex("serviceweaver/node")
 	ex("serviceweaver/component")
+	ex("serviceweaver/source")
 
 	// Process remaining labels.
 	time, err := time.Parse(time.RFC3339, ex("serviceweaver/time"))


### PR DESCRIPTION
In PR #5, I updated the GKE code to use the new log attribute names (e.g., source, msg). The PR was buggy though. Logs were being stored in Google Cloud Logging without a "file" or "line" label. The log catting code assumed these labels existed and failed when trying to parse them.

This CL fixes the bug. We store log entries in Google Cloud Logging with a file, line, and source label. This allows us to easily translate user's queries (e.g., `source.contains("foo")`) into Cloud Logging queries, while still easily extracting the file and line into a `LogEntry` proto.