### PR TITLE
Updated build_and_test to build binaries.

### DIFF
--- a/dev/build_and_test
+++ b/dev/build_and_test
@@ -45,6 +45,8 @@ function cmd_generate() {
 
 function cmd_build() {
   go build ./...
+  (cd cmd/weaver-gke && go build)
+  (cd cmd/weaver-gke-local && go build)
 }
 
 function cmd_vet() {


### PR DESCRIPTION
The binaries are used by `weaver gke` and `weaver gke-local`.