### PR TITLE
Fix the name resolution and load-balancing for GKE internal listeners.

### DIFF
--- a/internal/gke/cloud_patcher.go
+++ b/internal/gke/cloud_patcher.go
@@ -25,6 +25,8 @@ import (
 	compute "cloud.google.com/go/compute/apiv1"
 	container "cloud.google.com/go/container/apiv1"
 	"cloud.google.com/go/container/apiv1/containerpb"
+	dproto "github.com/ServiceWeaver/weaver-gke/internal/proto"
+	"github.com/ServiceWeaver/weaver/runtime/retry"
 	"github.com/googleapis/gax-go/v2/apierror"
 	"google.golang.org/api/dns/v1"
 	"google.golang.org/api/googleapi"
@@ -33,8 +35,6 @@ import (
 	artifactregistrypb "google.golang.org/genproto/googleapis/devtools/artifactregistry/v1beta2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	dproto "github.com/ServiceWeaver/weaver-gke/internal/proto"
-	"github.com/ServiceWeaver/weaver/runtime/retry"
 )
 
 // noRetryErr is an error that shouldn't be retried.
@@ -428,7 +428,6 @@ func patchCluster(ctx context.Context, config CloudConfig, opts patchOptions, lo
 }
 
 // patchDNSZone update the managed DNS zone with the new configuration.
-// TODO(spetrovic): Delete this function.
 func patchDNSZone(ctx context.Context, config CloudConfig, opts patchOptions, zone *dns.ManagedZone) error {
 	dnsService, err := dns.NewService(ctx, config.ClientOptions()...)
 	if err != nil {

--- a/internal/gke/gke.go
+++ b/internal/gke/gke.go
@@ -530,7 +530,7 @@ func ensureListenerService(ctx context.Context, cluster *ClusterInfo, logger *lo
 			Namespace: namespaceName,
 			Annotations: map[string]string{
 				serviceListenerKey:                lisEnc,
-				backendConfigServiceAnnotationKey: fmt.Sprintf(`{"default": "%s"}`, svcName),
+				backendConfigServiceAnnotationKey: fmt.Sprintf(`{"default": "%s"}`, backendConfigName),
 			},
 			Labels: map[string]string{
 				appNameKey:      dep.App.Name,


### PR DESCRIPTION
In particular:
  * Register the correct BackendConfig to the listener Service.
  * Add the default network to the DNS zone config.