### PR TITLE
Don't create the envelope with retry options for GKE deployers.

### DIFF
--- a/internal/gke/babysitter.go
+++ b/internal/gke/babysitter.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/envelope"
 	"github.com/ServiceWeaver/weaver/runtime/metrics"
 	"github.com/ServiceWeaver/weaver/runtime/protos"
-	"github.com/ServiceWeaver/weaver/runtime/retry"
 	"go.opentelemetry.io/otel/sdk/trace"
 )
 
@@ -113,7 +112,6 @@ func RunBabysitter(ctx context.Context) error {
 	}
 	defer traceExporter.Shutdown(ctx)
 
-	opts := envelope.Options{Restart: envelope.OnFailure, Retry: retry.DefaultOptions}
 	logSaver := logClient.Log
 	traceSaver := func(spans []trace.ReadOnlySpan) error {
 		return traceExporter.ExportSpans(ctx, spans)
@@ -123,7 +121,7 @@ func RunBabysitter(ctx context.Context) error {
 	}
 
 	m := &manager.HttpClient{Addr: cfg.ManagerAddr} // connection to the manager
-	b, err := babysitter.NewBabysitter(ctx, cfg, colocGroup, meta.PodName, false /*useLocalhost*/, m, logSaver, traceSaver, metricSaver, opts)
+	b, err := babysitter.NewBabysitter(ctx, cfg, colocGroup, meta.PodName, false /*useLocalhost*/, m, logSaver, traceSaver, metricSaver, envelope.Options{})
 	if err != nil {
 		return err
 	}

--- a/internal/local/babysitter.go
+++ b/internal/local/babysitter.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ServiceWeaver/weaver/runtime/metrics"
 	"github.com/ServiceWeaver/weaver/runtime/perfetto"
 	"github.com/ServiceWeaver/weaver/runtime/protos"
-	"github.com/ServiceWeaver/weaver/runtime/retry"
 	"github.com/google/uuid"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
@@ -68,11 +67,6 @@ func createBabysitter(ctx context.Context, cfg *config.GKEConfig,
 		return nil
 	}
 
-	opts := envelope.Options{
-		Restart: envelope.OnFailure,
-		Retry:   retry.DefaultOptions,
-	}
-
 	m := &manager.HttpClient{Addr: cfg.ManagerAddr} // connection to the manager
-	return babysitter.NewBabysitter(ctx, cfg, group, podName, true /*useLocalhost*/, m, logSaver, traceSaver, metricExporter, opts)
+	return babysitter.NewBabysitter(ctx, cfg, group, podName, true /*useLocalhost*/, m, logSaver, traceSaver, metricExporter, envelope.Options{})
 }


### PR DESCRIPTION
This will allow us to remove the code from the envelope for restarting the weavelet.

After this change, the GKE deployer will restart the babysitter jobs automatically, whenever the weavelet fails. For GKE local, no restarts will happen. (This should probably be changed in a future change.)