### PR TITLE
Added gke and gke-local version subcommands.

### DIFF
--- a/cmd/weaver-gke-local/main.go
+++ b/cmd/weaver-gke-local/main.go
@@ -27,6 +27,7 @@ func main() {
 		"kill":      gketool.KillCmd(&killSpec),
 		"profile":   gketool.ProfileCmd(&profileSpec),
 		"dashboard": gketool.DashboardCmd(&dashboardSpec),
+		"version":   tool.VersionCmd("weaver gke-local"),
 
 		// Hidden commands.
 		"store":       gketool.StoreCmd(&storeSpec),

--- a/cmd/weaver-gke/main.go
+++ b/cmd/weaver-gke/main.go
@@ -28,6 +28,7 @@ func main() {
 		"kill":      gketool.KillCmd(&killSpec),
 		"store":     gketool.StoreCmd(&storeSpec),
 		"profile":   gketool.ProfileCmd(&profileSpec),
+		"version":   tool.VersionCmd("weaver gke"),
 
 		// Hidden commands.
 		"controller":  &controllerCmd,

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	cloud.google.com/go/monitoring v1.12.0
 	cloud.google.com/go/security v1.10.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.11.0
-	github.com/ServiceWeaver/weaver v0.2.0
+	github.com/ServiceWeaver/weaver v0.3.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/cel-go v0.13.0
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.11.
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.35.0 h1:6KWug9hBDdc7s9a0BxnxtTXPwFcLpVx7IUKO1SLIaDE=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.35.0 h1:vjtrvX7B3S+uqTIOvOUfqsMCa3eEtEOOQWm7ERI1pxg=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.35.0/go.mod h1:H785fvlgotVZqht+1rHhXSs8EJ8uPVmpBYkTYO3ccpc=
-github.com/ServiceWeaver/weaver v0.2.0 h1:l+lHmRWul+BIz3gAOOvjurgU58WoPCWhLzxAf6jLwMM=
-github.com/ServiceWeaver/weaver v0.2.0/go.mod h1:LmdMKp+Oh0MiQwREZNQtWgVRjqn7sqQpk9gWOqCtFzo=
+github.com/ServiceWeaver/weaver v0.3.0 h1:Hln1XaIDY+SOUI5ePlnoFqm1f6EHN7UeCSjR2GO/ZU4=
+github.com/ServiceWeaver/weaver v0.3.0/go.mod h1:LmdMKp+Oh0MiQwREZNQtWgVRjqn7sqQpk9gWOqCtFzo=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=


### PR DESCRIPTION
This PR introduces "weaver gke version" and "weaver gke-local version" commands. See https://github.com/ServiceWeaver/weaver/pull/220 for context on version commands.

## Example

```console
$ weaver gke version
weaver gke: commit=aaef22370b9f511f896b249d2b45094f4849e37c deployer=v0.2.0 target=linux/amd64
$ weaver gke-local version
weaver gke-local: commit=aaef22370b9f511f896b249d2b45094f4849e37c deployer=v0.2.0 target=linux/amd64
```