### PR TITLE
Fix the fleet registration bug.

### DIFF
--- a/internal/gke/cloud_config.go
+++ b/internal/gke/cloud_config.go
@@ -97,11 +97,19 @@ func SetupCloudConfig(project, account string) (CloudConfig, error) {
 
 // checkSDK checks that Google Cloud SDK is installed.
 func checkSDK() error {
-	_, err := runCmd("", cmdOptions{}, "gcloud", "--version")
+	version, err := runCmd("", cmdOptions{}, "gcloud", "version", "--format=value(core)")
 	if err != nil {
 		return errors.New(`gcloud not installed.
 Follow these installation instructions:
 	https://cloud.google.com/sdk/docs/install`)
+	}
+
+	// Check the version.
+	const minVersion = "2023.04.25"
+	if version < minVersion {
+		return fmt.Errorf(
+			`unsupported gcloud version %q. Please run "gcloud components 
+update" to update to at least version %q`, version, minVersion)
 	}
 	return nil
 }

--- a/internal/gke/deploy.go
+++ b/internal/gke/deploy.go
@@ -1487,8 +1487,9 @@ func registerWithFleet(ctx context.Context, config CloudConfig, cluster *Cluster
 	_, err := runGcloud(config,
 		fmt.Sprintf("Registering cluster %q in %q with the project fleet",
 			cluster.Name, cluster.Region),
-		cmdOptions{}, "container", "fleet", "memberships",
-		"register", mName, "--gke-cluster", cName, "--enable-workload-identity",
+		cmdOptions{}, "container", "fleet", "memberships", "register", mName,
+		"--location", "global", "--gke-cluster", cName,
+		"--enable-workload-identity",
 	)
 	return err
 }


### PR DESCRIPTION
The bug was caused by the newer gcloud version, which now requires (and supports) the "--location" flag when creating a new memberhsip binding. These bindings no longer default to the "global" location, resulting in regional fleet memberships.

While at it, check the gcloud version before starting a deployment, and encourage users to update the gcloud to the latest version.