### PR TITLE
Secure the controller endpoint.

### DIFF
--- a/cmd/weaver-gke/controller.go
+++ b/cmd/weaver-gke/controller.go
@@ -16,20 +16,14 @@ package main
 
 import (
 	"context"
-	"flag"
 
 	"github.com/ServiceWeaver/weaver-gke/internal/gke"
 	"github.com/ServiceWeaver/weaver/runtime/tool"
 )
 
-var (
-	controllerFlags = flag.NewFlagSet("controller", flag.ContinueOnError)
-	controllerPort  = controllerFlags.Int("port", 0, "Controller port")
-)
-
 var controllerCmd = tool.Command{
 	Name:        "controller",
-	Flags:       controllerFlags,
+	Flags:       nil,
 	Description: "The GKE controller",
 	Help: `Usage:
   weaver gke controller
@@ -37,7 +31,7 @@ var controllerCmd = tool.Command{
 Flags:
   -h, --help   Print this help message.`,
 	Fn: func(ctx context.Context, args []string) error {
-		return gke.RunController(ctx, *controllerPort)
+		return gke.RunController(ctx)
 	},
 	Hidden: true,
 }

--- a/cmd/weaver-gke/distributor.go
+++ b/cmd/weaver-gke/distributor.go
@@ -16,20 +16,14 @@ package main
 
 import (
 	"context"
-	"flag"
 
 	"github.com/ServiceWeaver/weaver-gke/internal/gke"
 	"github.com/ServiceWeaver/weaver/runtime/tool"
 )
 
-var (
-	distributorFlags = flag.NewFlagSet("distributor", flag.ContinueOnError)
-	distributorPort  = distributorFlags.Int("port", 0, "Distributor port")
-)
-
 var distributorCmd = tool.Command{
 	Name:        "distributor",
-	Flags:       distributorFlags,
+	Flags:       nil,
 	Description: "The GKE distributor",
 	Help: `Usage:
   weaver gke distributor
@@ -37,7 +31,7 @@ var distributorCmd = tool.Command{
 Flags:
   -h, --help   Print this help message.`,
 	Fn: func(ctx context.Context, args []string) error {
-		return gke.RunDistributor(ctx, *distributorPort)
+		return gke.RunDistributor(ctx)
 	},
 	Hidden: true,
 }

--- a/cmd/weaver-gke/manager.go
+++ b/cmd/weaver-gke/manager.go
@@ -16,20 +16,14 @@ package main
 
 import (
 	"context"
-	"flag"
 
 	"github.com/ServiceWeaver/weaver-gke/internal/gke"
 	"github.com/ServiceWeaver/weaver/runtime/tool"
 )
 
-var (
-	managerFlags = flag.NewFlagSet("manager", flag.ContinueOnError)
-	managerPort  = managerFlags.Int("port", 0, "Manager port")
-)
-
 var managerCmd = tool.Command{
 	Name:        "manager",
-	Flags:       managerFlags,
+	Flags:       nil,
 	Description: "The GKE manager",
 	Help: `Usage:
   weaver gke manager
@@ -37,7 +31,7 @@ var managerCmd = tool.Command{
 Flags:
   -h, --help   Print this help message.`,
 	Fn: func(ctx context.Context, args []string) error {
-		return gke.RunManager(ctx, *managerPort)
+		return gke.RunManager(ctx)
 	},
 	Hidden: true,
 }

--- a/internal/gke/certs.go
+++ b/internal/gke/certs.go
@@ -15,10 +15,18 @@
 package gke
 
 import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
 	"os"
+
+	privateca "cloud.google.com/go/security/privateca/apiv1"
+	"cloud.google.com/go/security/privateca/apiv1/privatecapb"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 const (
@@ -32,8 +40,113 @@ const (
 	podKeyFile  = certsLocalDir + "/private_key.pem"
 )
 
+// createToolCertificate creates a new certificate that the tool can use to
+// authenticate itself with the controller. It returns the CA root certificate,
+// as well as the newly minted tool certificate and its private key.
+// REQUIRES: Called by the tool on the user machine.
+func createToolCertificate(ctx context.Context, config CloudConfig) (*x509.Certificate, []byte, []byte, error) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	var publicKeyPEM bytes.Buffer
+	if err := pem.Encode(&publicKeyPEM, &pem.Block{
+		Type:  "RSA PUBLIC KEY",
+		Bytes: x509.MarshalPKCS1PublicKey(&privKey.PublicKey),
+	}); err != nil {
+		return nil, nil, nil, err
+	}
+
+	client, err := privateca.NewCertificateAuthorityClient(ctx)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("cannot create PrivateCA client: %w", err)
+	}
+	defer client.Close()
+	certProto, err := client.CreateCertificate(ctx, &privatecapb.CreateCertificateRequest{
+		Parent:                        fmt.Sprintf("projects/%s/locations/%s/caPools/%s", config.Project, caLocation, caPoolName),
+		IssuingCertificateAuthorityId: caName,
+		Certificate: &privatecapb.Certificate{
+			CertificateConfig: &privatecapb.Certificate_Config{
+				Config: &privatecapb.CertificateConfig{
+					PublicKey: &privatecapb.PublicKey{
+						Key:    publicKeyPEM.Bytes(),
+						Format: privatecapb.PublicKey_PEM,
+					},
+					SubjectConfig: &privatecapb.CertificateConfig_SubjectConfig{
+						Subject: &privatecapb.Subject{
+							CountryCode: "US",
+							Province:    "California",
+						},
+						SubjectAltName: &privatecapb.SubjectAltNames{
+							Uris: []string{
+								// Match the URI for Pod-generated certificates.
+								fmt.Sprintf("spiffe://%s.svc.id.goog/ns/%s/sa/tool", config.Project, namespaceName),
+							},
+						},
+					},
+					X509Config: &privatecapb.X509Parameters{
+						KeyUsage: &privatecapb.KeyUsage{
+							BaseKeyUsage: &privatecapb.KeyUsage_KeyUsageOptions{
+								DigitalSignature: true,
+								KeyEncipherment:  true,
+							},
+							ExtendedKeyUsage: &privatecapb.KeyUsage_ExtendedKeyUsageOptions{
+								ServerAuth: true,
+								ClientAuth: true,
+							},
+						},
+					},
+				},
+			},
+			Lifetime: &durationpb.Duration{
+				Seconds: 3600, // 1h
+			},
+		},
+	})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Encode the private key.
+	keyDER, err := x509.MarshalPKCS8PrivateKey(privKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	var keyOut bytes.Buffer
+	if err := pem.Encode(&keyOut, &pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: keyDER,
+	}); err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Parse the root CA certificate from the response.
+	parse := func(certPEM, name string) (*x509.Certificate, error) {
+		certDER, _ := pem.Decode([]byte(certPEM))
+		if certDER == nil {
+			return nil, fmt.Errorf("cannot decode %s certificate DER block from PEM data", name)
+		}
+		cert, err := x509.ParseCertificate(certDER.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse certificate: %w", err)
+		}
+		return cert, err
+	}
+	n := len(certProto.PemCertificateChain)
+	if n == 0 {
+		return nil, nil, nil, fmt.Errorf("empty certificate verification chain")
+	}
+	caCert, err := parse(certProto.PemCertificateChain[n-1], "CA")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return caCert, []byte(certProto.PemCertificate), keyOut.Bytes(), nil
+}
+
 // getPodCerts returns the CA certificate stored on the Pod, as well as a
 // function that returns the latest Pod certificates.
+// REQUIRES: Called from inside a Pod.
 func getPodCerts() (*x509.Certificate, func() ([]byte, []byte, error), error) {
 	// Load the CA certificate.
 	caCertPEM, err := loadPEM(caCertFile)

--- a/internal/tool/deploy.go
+++ b/internal/tool/deploy.go
@@ -272,7 +272,7 @@ func (d *DeploySpec) startRollout(ctx context.Context, cfg *config.GKEConfig) er
 	ctx, cancel := context.WithTimeout(ctx, deployTimeout)
 	defer cancel()
 	for r := retry.Begin(); r.Continue(ctx); {
-		err := protomsg.Call(ctx, protomsg.CallArgs{
+		err = protomsg.Call(ctx, protomsg.CallArgs{
 			Client:  controllerClient,
 			Addr:    controllerAddr,
 			URLPath: controller.RolloutURL,


### PR DESCRIPTION
In particular, prevent an arbitrary code running inside the project to issue requests to the controller.

To secure the controller, we make the following changes:
  * Controller runs an HTTPS server.
  * Controller ensures that its clients have the "tool" identity signed by the project's Certificate Authority. (Note: this signing step is a privileged operation only available to the tool, which created the CA in the first place.)
  * Each time a tool command is invoked, it generates an ephemeral certificate with the "tool" identity and sends this certificate to the controller.
  * Controller listens on the public IP address, since the Kubernetes proxy doesn't support TLS passthrough.

Other changes:
  * Use port 443, which is the default port for HTTPS.
  * Remove port flags from nanny jobs. We already assumed those port values are fixed.