### PR TITLE
When cross-compiling, use the same tool version as on local machine.

### DIFF
--- a/internal/gke/build.go
+++ b/internal/gke/build.go
@@ -28,14 +28,18 @@ import (
 )
 
 var dockerfileTmpl = template.Must(template.New("Dockerfile").Parse(`
+{{if .GoInstall}}
+FROM golang:1.20-bullseye as builder
+RUN echo ""{{range .GoInstall}} && go install {{.}}{{end}}
+{{end}}
 FROM ubuntu:rolling
 WORKDIR /weaver/
 RUN apt-get update
 RUN apt-get install -y ca-certificates
-RUN apt-get install -y golang-go{{range .GoInstall}}
-RUN GOPATH=/weaver/ go install {{.}}{{end}}
-RUN if [ "$(ls -A /weaver/bin)" ]; then cp /weaver/bin/* /weaver/; fi
 COPY . .
+{{if .GoInstall}}
+COPY --from=builder /go/bin/ /weaver/
+{{end}}
 ENTRYPOINT ["/bin/bash", "-c"]
 `))
 

--- a/internal/gke/deploy.go
+++ b/internal/gke/deploy.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ServiceWeaver/weaver-gke/internal/nanny/controller"
 	"github.com/ServiceWeaver/weaver-gke/internal/nanny/distributor"
 	"github.com/ServiceWeaver/weaver-gke/internal/proto"
+	"github.com/ServiceWeaver/weaver-gke/internal/version"
 	"github.com/ServiceWeaver/weaver/runtime/bin"
 	"github.com/ServiceWeaver/weaver/runtime/retry"
 	"google.golang.org/api/cloudresourcemanager/v1"
@@ -214,7 +215,8 @@ func PrepareRollout(ctx context.Context, config CloudConfig, cfg *config.GKEConf
 		files = append(files, toolBinPath)
 	} else {
 		// Cross-compile the weaver-gke tool binary inside the container.
-		goInstall = append(goInstall, "github.com/ServiceWeaver/weaver-gke/cmd/weaver-gke@latest")
+		toolVersion := fmt.Sprintf("v%d.%d.%d", version.Major, version.Minor, version.Patch)
+		goInstall = append(goInstall, "github.com/ServiceWeaver/weaver-gke/cmd/weaver-gke@"+toolVersion)
 	}
 	go func() {
 		defer close(buildDone)


### PR DESCRIPTION
Previously, we would always use the `@latest` tool version, which leads to compatibility issues. This change ensures that the user runs the same tool version locally and inside the cloud.

Other changes:
      * Simplify Go builds using the separate image to do the builds. This was suggested by one of the contributors for the
	weaver-kube repository.