### PR TITLE
A couple of GKE-related fixes.

### DIFF
--- a/internal/gke/build.go
+++ b/internal/gke/build.go
@@ -109,6 +109,8 @@ steps:
   - '.'
 images: {{range $tag := .Tags}}
   - '{{$tag}}' {{end}}
+options:
+  logging: CLOUD_LOGGING_ONLY
 `
 	if err := template.Must(template.New("cloudbuild").Parse(tmpl)).Execute(cloudbuildFile, spec); err != nil {
 		cloudbuildFile.Close()

--- a/internal/gke/deploy.go
+++ b/internal/gke/deploy.go
@@ -139,6 +139,7 @@ func PrepareRollout(ctx context.Context, config CloudConfig, cfg *config.GKEConf
 		"multiclusterservicediscovery.googleapis.com",
 		"multiclusteringress.googleapis.com",
 		"privateca.googleapis.com",
+		"serviceusage.googleapis.com",
 		"trafficdirector.googleapis.com",
 	); err != nil {
 		return nil, err

--- a/internal/tool/deploy.go
+++ b/internal/tool/deploy.go
@@ -274,11 +274,13 @@ func (d *DeploySpec) startRollout(ctx context.Context, cfg *config.GKEConfig) er
 	if err := pickDeployRegions(cfg); err != nil {
 		return err
 	}
-	controllerAddr, controllerClient, err := d.Controller(ctx, cfg)
+
+	req, err := d.PrepareRollout(ctx, cfg)
 	if err != nil {
 		return err
 	}
-	req, err := d.PrepareRollout(ctx, cfg)
+
+	controllerAddr, controllerClient, err := d.Controller(ctx, cfg)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Namely:
  * Disable build logging to storage buckets, as it requires extra permissions.
  * Enable an additional cloud service api (service usage).
  * Acquire controller address only after the config cluster has been created. (d'oh).