### PR TITLE
Fix a race in creating CA certificate/key between tool and controller.

### DIFF
--- a/internal/local/certs_test.go
+++ b/internal/local/certs_test.go
@@ -1,0 +1,42 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package local
+
+import (
+	"crypto/x509"
+	"testing"
+
+	"github.com/ServiceWeaver/weaver-gke/internal/mtls"
+)
+
+func TestGenerateSignedCert(t *testing.T) {
+	caCert, caKey, err := generateLeafCert(true /*isCA*/, "ca")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, _, err := generateSignedCert(caCert, caKey, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the signed certificate.
+	name, err := mtls.VerifyCertificateChain("local", caCert, []*x509.Certificate{cert})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != "test" {
+		t.Errorf("unexpected certificate name, want %q, got %q", "test", name)
+	}
+}

--- a/internal/local/tool.go
+++ b/internal/local/tool.go
@@ -41,6 +41,12 @@ const (
 // PrepareRollout returns a new rollout request for the given application
 // version. This call may mutate the passed-in config.
 func PrepareRollout(ctx context.Context, cfg *config.GKEConfig) (*controller.RolloutRequest, error) {
+	// Ensure the CA certificate/key files have been created on the local
+	// machine. This ensures that there is no race when creating these files
+	// between the tool and weaver services below (i.e., controller,
+	// distributor, and manager).
+	ensureCACert()
+
 	// Ensure all Service Weaver service processes (i.e., controller,
 	// distributor/manager) are running.
 	distributorPorts, err := ensureWeaverServices(ctx, cfg)


### PR DESCRIPTION
This race was introduced by a recent change where we changed the order of calls to `Controller` and `PrepareRollout` while deploying. This introduced a known race where the controller and the tool attempt to create and store the shared CA certificate key on the local file system. In turn, this caused the tool and the controller to use different CA certificates, resulting in a TLS error between them.

This change restores the old behavior of the tool generating the CA certificate before starting the controller.

Other changes:
  * Add a simple test for certificates (unrelated to this fix).