### PR TITLE
Don't report localhost addresses on GKE. (d'oh)

### DIFF
--- a/internal/gke/babysitter.go
+++ b/internal/gke/babysitter.go
@@ -135,7 +135,11 @@ func RunBabysitter(ctx context.Context) error {
 		TLSConfig: mtls.ClientTLSConfig(meta.Project, caCert, getSelfCert, "manager"),
 	}
 	mux := http.NewServeMux()
-	lis, err := net.Listen("tcp", "localhost:0")
+	host, err := os.Hostname()
+	if err != nil {
+		return err
+	}
+	lis, err := net.Listen("tcp", fmt.Sprintf("%s:0", host))
 	if err != nil {
 		return err
 	}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -18,5 +18,5 @@ const (
 	// weaver-gke module version (Major.Minor.Patch).
 	Major = 0
 	Minor = 18
-	Patch = 0
+	Patch = 2
 )


### PR DESCRIPTION
This fixes the endpoint health-checks that are currently failing at the assigner.