### PR TITLE
Use the Pod watcher to detect the set of remote component replicas.

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -79,7 +79,7 @@ jobs:
       # TODO(spetrovic): use the hostname directly once we change the DNS
       # records to point to the IP address below.
       run: |
-        timeout ${{ env.WAIT_TIMEOUT }} /bin/sh -c 'while true; do wget -O- -T 10 --header "Host: ${{env.VERSION}}.echo.serviceweaver.dev" http://34.36.187.160:80?s=testme && break; sleep 15; done'
+        timeout ${{ env.WAIT_TIMEOUT }} /bin/sh -c 'while true; do wget -O- -T 10 --header "Host: ${{env.VERSION}}.echo.serviceweaver.dev" http://34.36.121.96:80?s=testme && break; sleep 15; done'
 
     - name: Cleanup the echo app
       if: always()

--- a/examples/echo/weaver.toml
+++ b/examples/echo/weaver.toml
@@ -1,0 +1,12 @@
+[serviceweaver]
+binary = "./echo"
+
+[single]
+listeners.echo = {address = "localhost:9000"}
+
+[multi]
+listeners.echo = {address = "localhost:9000"}
+
+[gke]
+regions = ["us-west1"]
+listeners.echo = {public_hostname = "echo.example.com"} 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	cloud.google.com/go/monitoring v1.12.0
 	cloud.google.com/go/security v1.10.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.11.0
-	github.com/ServiceWeaver/weaver v0.18.0
+	github.com/ServiceWeaver/weaver v0.18.1
 	github.com/golang/protobuf v1.5.2
 	github.com/google/cel-go v0.17.1
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.11.
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.35.0 h1:6KWug9hBDdc7s9a0BxnxtTXPwFcLpVx7IUKO1SLIaDE=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.35.0 h1:vjtrvX7B3S+uqTIOvOUfqsMCa3eEtEOOQWm7ERI1pxg=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.35.0/go.mod h1:H785fvlgotVZqht+1rHhXSs8EJ8uPVmpBYkTYO3ccpc=
-github.com/ServiceWeaver/weaver v0.18.0 h1:b62r1E9mYnCaPEH+KOT34FsMjSZNLFSlXEnNLTR0pyM=
-github.com/ServiceWeaver/weaver v0.18.0/go.mod h1:/tJzitb+h8nLeHa4Mk7iIGU5ZV4OGB4C9IvIfD8n/1I=
+github.com/ServiceWeaver/weaver v0.18.1 h1:SE3YhFO58xm3zjYY1wF4Lbz928m27tmQdnbEsdagil4=
+github.com/ServiceWeaver/weaver v0.18.1/go.mod h1:/tJzitb+h8nLeHa4Mk7iIGU5ZV4OGB4C9IvIfD8n/1I=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/internal/local/cond/cond.go
+++ b/internal/local/cond/cond.go
@@ -1,0 +1,94 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cond implements a context-aware condition variable.
+package cond
+
+import (
+	"context"
+	"sync"
+)
+
+// # Implementation Overview
+//
+// When a goroutine calls cond.Wait(ctx), Wait creates a channel and appends it
+// to a queue of waiting channels inside of cond. It then performs a select on
+// ctx.Done and the newly minted channel. Signal pops the first waiting channel
+// and closes it. Broadcast pops and closes every waiting channel.
+
+// Cond is a context-aware version of a sync.Cond. Like a sync.Cond, a Cond
+// must not be copied after first use.
+type Cond struct {
+	L sync.Locker
+
+	// Note that we need our own mutex instead of using L because Signal and
+	// Broadcast can be called without holding L.
+	m       sync.Mutex
+	waiters []chan struct{}
+}
+
+// NewCond returns a new Cond with Locker l.
+func NewCond(l sync.Locker) *Cond {
+	return &Cond{L: l}
+}
+
+// Broadcast is identical to sync.Cond.Broadcast.
+func (c *Cond) Broadcast() {
+	c.m.Lock()
+	defer c.m.Unlock()
+	for _, wait := range c.waiters {
+		close(wait)
+	}
+	c.waiters = nil
+}
+
+// Signal is identical to sync.Cond.Signal.
+func (c *Cond) Signal() {
+	c.m.Lock()
+	defer c.m.Unlock()
+	if len(c.waiters) == 0 {
+		return
+	}
+	wait := c.waiters[0]
+	c.waiters = c.waiters[1:]
+	close(wait)
+}
+
+// Wait behaves identically to sync.Cond.Wait, except that it respects the
+// provided context. Specifically, if the context is cancelled, c.L is
+// reacquired and ctx.Err() is returned. Example usage:
+//
+//	for !condition() {
+//	    if err := cond.Wait(ctx); err != nil {
+//	        // The context was cancelled. cond.L is locked at this point.
+//	        return err
+//	    }
+//	    // Wait returned normally. cond.L is still locked at this point.
+//	}
+func (c *Cond) Wait(ctx context.Context) error {
+	wait := make(chan struct{})
+	c.m.Lock()
+	c.waiters = append(c.waiters, wait)
+	c.m.Unlock()
+
+	c.L.Unlock()
+	var err error
+	select {
+	case <-ctx.Done():
+		err = ctx.Err()
+	case <-wait:
+	}
+	c.L.Lock()
+	return err
+}

--- a/internal/local/cond/cond_test.go
+++ b/internal/local/cond/cond_test.go
@@ -1,0 +1,378 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cond_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ServiceWeaver/weaver-gke/internal/local/cond"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+// TestCancelledWait tests that a Wait on a cancelled context returns promptly
+// with the context's error.
+func TestCancelledWait(t *testing.T) {
+	var m sync.Mutex
+	c := cond.NewCond(&m)
+	errs := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		m.Lock()
+		defer m.Unlock()
+		errs <- c.Wait(ctx)
+	}()
+
+	timer := time.NewTimer(100 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-errs:
+		if got, want := err, ctx.Err(); got != want {
+			t.Fatalf("bad error: got %v, want %v", got, want)
+		}
+	case <-timer.C:
+		t.Fatal("cancelled Wait() did not terminate promptly")
+	}
+}
+
+// TestSignal tests that a Signal wakes up a goroutine blocked on Wait.
+func TestSignal(t *testing.T) {
+	var m sync.Mutex
+	c := cond.NewCond(&m)
+	errs := make(chan error, 1)
+	ctx := context.Background()
+
+	waiting := false
+	waiter := func() {
+		m.Lock()
+		defer m.Unlock()
+		waiting = true
+		errs <- c.Wait(ctx)
+	}
+	signaler := func() {
+		// If we call Signal before the waiter goroutine calls Wait, then the
+		// Signal is a noop and the Wait blocks forever.
+		for {
+			m.Lock()
+			b := waiting
+			m.Unlock()
+
+			if b {
+				c.Signal()
+				return
+			}
+			time.Sleep(1 * time.Millisecond)
+		}
+	}
+	go waiter()
+	go signaler()
+
+	timer := time.NewTimer(100 * time.Millisecond)
+	select {
+	case err := <-errs:
+		if err != nil {
+			t.Fatalf("unexpected error %v", err)
+		}
+	case <-timer.C:
+		t.Fatal("signalled Wait() did not terminate promptly")
+	}
+}
+
+// TestBroadcast tests that a Broadcast wakes up all goroutines blocked on
+// Wait.
+func TestBroadcast(t *testing.T) {
+	var m sync.Mutex
+	c := cond.NewCond(&m)
+	numWaiters := 10
+	errs := make(chan error, numWaiters)
+	ctx := context.Background()
+
+	numWaiting := 0
+	waiter := func() {
+		m.Lock()
+		defer m.Unlock()
+		numWaiting += 1
+		errs <- c.Wait(ctx)
+	}
+	broadcaster := func() {
+		// If we call Broadcast before the waiter goroutine calls Wait, then
+		// the Broadcast is a noop and the Wait blocks forever.
+		for {
+			m.Lock()
+			b := numWaiting == numWaiters
+			m.Unlock()
+
+			if b {
+				c.Broadcast()
+				return
+			}
+			time.Sleep(1 * time.Millisecond)
+		}
+	}
+	for i := 0; i < numWaiters; i++ {
+		go waiter()
+	}
+	go broadcaster()
+
+	timer := time.NewTimer(100 * time.Millisecond)
+	for i := 0; i < numWaiters; i++ {
+		select {
+		case err := <-errs:
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+		case <-timer.C:
+			t.Fatal("broadcasted Wait()'s did not terminate promptly")
+		}
+	}
+}
+
+// queue is a blocking concurrent queue.
+type queue interface {
+	Pop(ctx context.Context) (int, error)
+	Push(x int) error
+}
+
+// broadcaster is a queue that uses cond.Broadcast.
+type broadcaster struct {
+	lockedBroadcast bool // if true, hold m when broadcasting
+
+	m        sync.Mutex // used by nonempty, guards xs
+	nonempty cond.Cond  // triggered when xs is non-empty
+	xs       []int      // the underlying queue elements
+}
+
+// Check that broadcaster implements the queue interface.
+var _ queue = &broadcaster{}
+
+func newBroadcaster(lockedBroadcast bool) *broadcaster {
+	var q broadcaster
+	q.nonempty.L = &q.m
+	q.xs = []int{}
+	q.lockedBroadcast = lockedBroadcast
+	return &q
+}
+
+func (q *broadcaster) Pop(ctx context.Context) (int, error) {
+	q.m.Lock()
+	defer q.m.Unlock()
+
+	for len(q.xs) == 0 {
+		if err := q.nonempty.Wait(ctx); err != nil {
+			return 0, err
+		}
+	}
+	x := q.xs[0]
+	q.xs = q.xs[1:]
+	return x, nil
+}
+
+func (q *broadcaster) Push(x int) error {
+	q.m.Lock()
+	if q.lockedBroadcast {
+		defer q.m.Unlock()
+	}
+	q.xs = append(q.xs, x)
+	if !q.lockedBroadcast {
+		q.m.Unlock()
+	}
+	q.nonempty.Broadcast()
+	return nil
+}
+
+// signaler is a queue that uses cond.Signal.
+type signaler struct {
+	lockedSignal bool // if true, hold m when signalling
+
+	m        sync.Mutex // used by nonempty, guards xs
+	nonempty cond.Cond  // signalled when xs is non-empty
+	xs       []int      // the underlying queue elements
+}
+
+// Check that signaler implements the queue interface.
+var _ queue = &signaler{}
+
+func newSignaler(lockedSignal bool) *signaler {
+	var q signaler
+	q.nonempty.L = &q.m
+	q.xs = []int{}
+	q.lockedSignal = lockedSignal
+	return &q
+}
+
+func (q *signaler) Pop(ctx context.Context) (int, error) {
+	q.m.Lock()
+	if q.lockedSignal {
+		defer q.m.Unlock()
+	}
+
+	for len(q.xs) == 0 {
+		if err := q.nonempty.Wait(ctx); err != nil {
+			if !q.lockedSignal {
+				q.m.Unlock()
+			}
+			return 0, err
+		}
+	}
+	x := q.xs[0]
+	q.xs = q.xs[1:]
+	n := len(q.xs)
+
+	if !q.lockedSignal {
+		q.m.Unlock()
+	}
+	if n > 0 {
+		q.nonempty.Signal()
+	}
+	return x, nil
+}
+
+func (q *signaler) Push(x int) error {
+	q.m.Lock()
+	if q.lockedSignal {
+		defer q.m.Unlock()
+	}
+	q.xs = append(q.xs, x)
+	if !q.lockedSignal {
+		q.m.Unlock()
+	}
+	q.nonempty.Signal()
+	return nil
+}
+
+func TestQueues(t *testing.T) {
+	for _, q := range []struct {
+		name string
+		q    func() queue
+	}{
+		{"LockedBroadcaster", func() queue { return newBroadcaster(true) }},
+		{"UnlockedBroadcaster", func() queue { return newBroadcaster(false) }},
+		{"LockedSignaler", func() queue { return newSignaler(true) }},
+		{"UnlockedSignaler", func() queue { return newSignaler(false) }},
+	} {
+		for _, test := range []struct {
+			name string
+			f    func(*testing.T, queue)
+		}{
+			{"TestPopEmpty", testPopEmpty},
+			{"TestPushPops", testPushPops},
+			{"TestPushNoPops", testPushNoPops},
+		} {
+			name := fmt.Sprintf("%s/%s", q.name, test.name)
+			t.Run(name, func(t *testing.T) { test.f(t, q.q()) })
+		}
+	}
+}
+
+// testPopEmpty tests that Pop respects the context it receives.
+func testPopEmpty(t *testing.T, q queue) {
+	ctx, cancel := context.WithCancel(context.Background())
+	errs := make(chan error, 1)
+	go func() {
+		_, err := q.Pop(ctx)
+		errs <- err
+	}()
+
+	timer := time.NewTimer(100 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-errs:
+		if got, want := err, ctx.Err(); got != want {
+			t.Fatalf("bad error: got %v, want %v", got, want)
+		}
+	case <-timer.C:
+		t.Fatal("cancelled Pop() did not terminate promptly")
+	}
+}
+
+// testPushPops tests that concurrent pushes and pops work correctly.
+func testPushPops(t *testing.T, q queue) {
+	numPoppers := 3
+	numPushers := 10
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	popped := make(chan int, numPushers)
+	popper := func() error {
+		for {
+			x, err := q.Pop(ctx)
+			if err != nil {
+				return err
+			}
+			popped <- x
+		}
+	}
+
+	pusher := func(i int) error {
+		return q.Push(i)
+	}
+
+	// Launch goroutines.
+	var done sync.WaitGroup
+	done.Add(numPoppers + numPushers)
+	errs := make(chan error, numPoppers+numPushers)
+	for i := 0; i < numPoppers; i++ {
+		go func() {
+			defer done.Done()
+			errs <- popper()
+		}()
+	}
+	for i := 0; i < numPushers; i++ {
+		i := i
+		go func() {
+			defer done.Done()
+			errs <- pusher(i)
+		}()
+	}
+	done.Wait()
+
+	// Check for errors.
+	close(errs)
+	for err := range errs {
+		if err != nil && err != ctx.Err() {
+			t.Error(err)
+		}
+	}
+
+	// Check popped values.
+	close(popped)
+	got := []int{}
+	for x := range popped {
+		got = append(got, x)
+	}
+	want := []int{}
+	for i := 0; i < numPushers; i++ {
+		want = append(want, i)
+	}
+	less := func(x, y int) bool { return x < y }
+	if diff := cmp.Diff(want, got, cmpopts.SortSlices(less)); diff != "" {
+		t.Fatalf("(-want +got):\n%s", diff)
+	}
+}
+
+// testPushNoPops tests that Push works correctly when there are no poppers. In
+// turn, this tests that a Signal or Brodacast works correctly when there are
+// no waiters.
+func testPushNoPops(t *testing.T, q queue) {
+	for i := 0; i < 10; i++ {
+		if err := q.Push(i); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/internal/local/nanny.go
+++ b/internal/local/nanny.go
@@ -300,7 +300,7 @@ func RunManager(ctx context.Context, region string, port, proxyPort int) error {
 		return fmt.Errorf("cannot get the store: %w", err)
 	}
 	s = store.WithMetrics(name, id, s)
-	starter, err := NewStarter(s)
+	starter, err := NewStarter()
 	if err != nil {
 		return fmt.Errorf("cannot create starter: %w", err)
 	}


### PR DESCRIPTION
This change mimics the related change in weaver-kube where the babysitter watches the activated component's pods and returns the replicas therein. The GKE deployer was previously consulting the assigner for an updated set of replicas, which is a complicated flow fraught with possibilities of errors.

Moreover, an upcoming weaver change will see weavelets performing health checks themselves, obsoleting the current GKE mechanism which has the assigner performing health checks on the babysitters.

TODO: Change the assigner to only manage routing information for routed components.

Other changes:
  * Fix labeling for all resources to produce values that are guaranteed DNS labels (e.g., replica sets often aren't).
  * Minor code fixes.