### PR TITLE
A few permissions-related changes.

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ name: Integration Test
 
 env:
     CONFIG_FILE: deploy.toml
-    WAIT_TIMEOUT: "15m"
+    WAIT_TIMEOUT: "25m"
 
 on:
   schedule:

--- a/internal/gke/cloud_patcher.go
+++ b/internal/gke/cloud_patcher.go
@@ -224,11 +224,14 @@ func patchSSLCertificate(ctx context.Context, config CloudConfig, opts patchOpti
 			return old, nil
 		},
 		create: func() error {
-			_, err := client.Insert(ctx, &computepb.InsertSslCertificateRequest{
+			op, err := client.Insert(ctx, &computepb.InsertSslCertificateRequest{
 				SslCertificateResource: cert,
 				Project:                config.Project,
 			})
-			return err
+			if err != nil {
+				return err
+			}
+			return op.Wait(ctx)
 		},
 		update: func(updateVal interface{}) error {
 			// Neither Update or a Patch API exists.  We also cannot delete the

--- a/internal/gke/kube_patcher.go
+++ b/internal/gke/kube_patcher.go
@@ -293,12 +293,12 @@ func patchKubeServiceAccount(ctx context.Context, cluster *ClusterInfo, opts pat
 	}.Run(ctx, account)
 }
 
-// patchClusterRole updates the kubernetes cluser role with the new configuration.
-func patchClusterRole(ctx context.Context, cluster *ClusterInfo, opts patchOptions, role *rbacv1.ClusterRole) error {
-	cli := cluster.Clientset.RbacV1().ClusterRoles()
+// patchRole updates the kubernetes role with the new configuration.
+func patchRole(ctx context.Context, cluster *ClusterInfo, opts patchOptions, role *rbacv1.Role) error {
+	cli := cluster.Clientset.RbacV1().Roles(getNamespace(role.ObjectMeta))
 	return kubePatcher{
 		cluster: cluster,
-		desc:    "cluster role",
+		desc:    "role",
 		opts:    opts,
 		get: func(ctx context.Context) (metav1.Object, error) {
 			return cli.Get(ctx, role.Name, metav1.GetOptions{})


### PR DESCRIPTION
Namely:
  * Use a Kubernetes Role instead of a ClusterRole. The former is namespace-scoped, so it fits our use-case better.
  * Don't create a Role per component. Instead, create a single "application" role and use it across the components.
  * Explicitly specify deletion permissions for rolebindings, as using the "*" doesn't seem to work for some reason.

The above changes, in addition to being more sensible, also fix the cleanup issue where the deletion of older version was failing.