### PR TITLE
Use the same hostname for all versions of the echo app.

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -67,7 +67,10 @@ jobs:
 
         [gke]
         regions= ["us-west1"]
-        listeners.echo = {public_hostname = "${{env.VERSION}}.echo.serviceweaver.dev"}
+        listeners.echo = {public_hostname = "echo.serviceweaver.dev"}
+
+        ["github.com/ServiceWeaver/weaver-gke/examples/echo/Echoer"]
+        Pattern = "${{env.VERSION}}"
         EOF
         )
         echo "$CONFIG" > ${{ env.CONFIG_FILE }}
@@ -79,7 +82,7 @@ jobs:
       # TODO(spetrovic): use the hostname directly once we change the DNS
       # records to point to the IP address below.
       run: |
-        timeout ${{ env.WAIT_TIMEOUT }} /bin/sh -c 'while true; do wget -O- -T 10 --header "Host: ${{env.VERSION}}.echo.serviceweaver.dev" http://34.36.121.96:80?s=testme && break; sleep 15; done'
+        timeout ${{ env.WAIT_TIMEOUT }} /bin/sh -c 'while true; do wget -O- -T 10 --header "Host: echo.serviceweaver.dev" http://34.36.121.96:80?s=${{env.VERSION}} && break; sleep 15; done'
 
     - name: Cleanup the echo app
       if: always()


### PR DESCRIPTION
Currently, GCP has a rather small default limit on the number of SSL certificates it can maintain. Additionally, we don't have a good way of deleting certificates when they are no longer needed. For this reason, we temporarily reduce the number of certificates by reusing the same hostname in integration tests, namely, "echo.serviceweaver.dev".

We will implement correct certificate deletion in a future change.