### PR TITLE
Change the tool to read the version information from the running binary.

### DIFF
--- a/cmd/weaver-gke-local/version.go
+++ b/cmd/weaver-gke-local/version.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/ServiceWeaver/weaver-gke/internal/version"
+	"github.com/ServiceWeaver/weaver-gke/internal/gke"
 	"github.com/ServiceWeaver/weaver/runtime/tool"
 )
 
@@ -30,7 +30,11 @@ var versionCmd = tool.Command{
 	Description: "Show weaver gke-local version",
 	Help:        "Usage:\n  weaver gke-local version",
 	Fn: func(context.Context, []string) error {
-		fmt.Printf("weaver gke-local v%d.%d.%d %s/%s\n", version.Major, version.Minor, version.Patch, runtime.GOOS, runtime.GOARCH)
+		v, _, err := gke.ToolVersion()
+		if err != nil {
+			return err
+		}
+		fmt.Printf("weaver gke-local %s %s/%s\n", v, runtime.GOOS, runtime.GOARCH)
 		return nil
 	},
 }

--- a/cmd/weaver-gke/version.go
+++ b/cmd/weaver-gke/version.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/ServiceWeaver/weaver-gke/internal/version"
+	"github.com/ServiceWeaver/weaver-gke/internal/gke"
 	"github.com/ServiceWeaver/weaver/runtime/tool"
 )
 
@@ -30,7 +30,11 @@ var versionCmd = tool.Command{
 	Description: "Show weaver gke version",
 	Help:        "Usage:\n  weaver gke version",
 	Fn: func(context.Context, []string) error {
-		fmt.Printf("weaver gke v%d.%d.%d %s/%s\n", version.Major, version.Minor, version.Patch, runtime.GOOS, runtime.GOARCH)
+		v, _, err := gke.ToolVersion()
+		if err != nil {
+			return err
+		}
+		fmt.Printf("weaver gke %s %s/%s\n", v, runtime.GOOS, runtime.GOARCH)
 		return nil
 	},
 }

--- a/internal/gke/version.go
+++ b/internal/gke/version.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,11 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package version
+package gke
 
-const (
-	// weaver-gke module version (Major.Minor.Patch).
-	Major = 0
-	Minor = 21
-	Patch = 0
+import (
+	"fmt"
+	"runtime/debug"
 )
+
+// ToolVersion returns the version of the running tool binary, along with
+// an indication whether the tool was built manually, i.e., not via go install.
+func ToolVersion() (string, bool, error) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		// Should never happen.
+		return "", false, fmt.Errorf("tool binary must be built from a module")
+	}
+	dev := info.Main.Version == "(devel)"
+	return info.Main.Version, dev, nil
+}


### PR DESCRIPTION
This simplifies the release process as it removes the redundant version tracking we used to do manually. It also means versions can be more fine-grained (e.g., at the github commit level).