### PR TITLE
Capture GKE local sub-process stderr and stdout.

### DIFF
--- a/cmd/weaver-gke-local/controller.go
+++ b/cmd/weaver-gke-local/controller.go
@@ -24,6 +24,7 @@ import (
 
 var (
 	controllerFlags  = flag.NewFlagSet("controller", flag.ContinueOnError)
+	controllerId     = controllerFlags.String("id", "", "controller unique id")
 	controllerRegion = controllerFlags.String("region", "us-central1", "Simulated GKE region")
 	controllerPort   = controllerFlags.Int("port", 0, "Controller port")
 )
@@ -38,7 +39,7 @@ var controllerCmd = tool.Command{
 Flags:
   -h, --help   Print this help message.`,
 	Fn: func(ctx context.Context, args []string) error {
-		return local.RunController(ctx, *controllerRegion, *controllerPort)
+		return local.RunController(ctx, *controllerId, *controllerRegion, *controllerPort)
 	},
 	Hidden: true,
 }

--- a/cmd/weaver-gke-local/distributor.go
+++ b/cmd/weaver-gke-local/distributor.go
@@ -24,6 +24,7 @@ import (
 
 var (
 	distributorFlags       = flag.NewFlagSet("distributor", flag.ContinueOnError)
+	distributorId          = distributorFlags.String("id", "", "distributor unique id")
 	distributorRegion      = distributorFlags.String("region", "us-west1", "Simulated GKE region")
 	distributorPort        = distributorFlags.Int("port", 0, "Distributor port")
 	distributorManagerPort = distributorFlags.Int("manager_port", 0, "Local manager port")
@@ -39,7 +40,7 @@ var distributorCmd = tool.Command{
 Flags:
   -h, --help   Print this help message.`,
 	Fn: func(ctx context.Context, args []string) error {
-		return local.RunDistributor(ctx, *distributorRegion, *distributorPort, *distributorManagerPort)
+		return local.RunDistributor(ctx, *distributorId, *distributorRegion, *distributorPort, *distributorManagerPort)
 	},
 	Hidden: true,
 }

--- a/cmd/weaver-gke-local/manager.go
+++ b/cmd/weaver-gke-local/manager.go
@@ -24,6 +24,7 @@ import (
 
 var (
 	managerFlags     = flag.NewFlagSet("manager", flag.ContinueOnError)
+	managerId        = managerFlags.String("id", "", "manager unique id")
 	managerRegion    = managerFlags.String("region", "us-west1", "Simulated GKE region")
 	managerPort      = managerFlags.Int("port", 0, "Manager port")
 	managerProxyPort = managerFlags.Int("proxy_port", 0, "Proxy port")
@@ -39,7 +40,7 @@ var managerCmd = tool.Command{
 Flags:
   -h, --help   Print this help message.`,
 	Fn: func(ctx context.Context, args []string) error {
-		return local.RunManager(ctx, *managerRegion, *managerPort, *managerProxyPort)
+		return local.RunManager(ctx, *managerId, *managerRegion, *managerPort, *managerProxyPort)
 	},
 	Hidden: true,
 }

--- a/cmd/weaver-gke-local/proxy.go
+++ b/cmd/weaver-gke-local/proxy.go
@@ -24,6 +24,7 @@ import (
 
 var (
 	proxyFlags = flag.NewFlagSet("proxy", flag.ContinueOnError)
+	proxyId    = proxyFlags.String("id", "", "proxy unique id")
 	proxyPort  = proxyFlags.Int("port", 0, "proxy port")
 )
 
@@ -31,13 +32,13 @@ var proxyCmd = tool.Command{
 	Name:        "proxy",
 	Description: "The gke-local proxy",
 	Help: `Usage:
-  weaver gke-local proxy --port=<port>
+  weaver gke-local proxy --id=<id> --port=<port>
 
 Flags:
   -h, --help   Print this help message.`,
 	Flags: proxyFlags,
 	Fn: func(ctx context.Context, _ []string) error {
-		return local.RunProxy(ctx, *proxyPort)
+		return local.RunProxy(ctx, *proxyId, *proxyPort)
 	},
 	Hidden: true,
 }

--- a/internal/babysitter/logger.go
+++ b/internal/babysitter/logger.go
@@ -16,8 +16,6 @@ package babysitter
 
 import (
 	"context"
-	"fmt"
-	"os"
 
 	"github.com/ServiceWeaver/weaver"
 	"github.com/ServiceWeaver/weaver/runtime/protos"
@@ -40,7 +38,6 @@ type loggerImpl struct {
 var _ funcLogger = &loggerImpl{}
 
 func (l *loggerImpl) LogBatch(ctx context.Context, batch *protos.LogEntryBatch) error {
-	fmt.Fprintf(os.Stderr, "LogBatch %d\n", len(batch.Entries))
 	for _, e := range batch.Entries {
 		l.dst(e)
 	}

--- a/internal/local/nanny.go
+++ b/internal/local/nanny.go
@@ -53,7 +53,6 @@ import (
 	"github.com/ServiceWeaver/weaver-gke/internal/store"
 	"github.com/ServiceWeaver/weaver/runtime/logging"
 	protos "github.com/ServiceWeaver/weaver/runtime/protos"
-	"github.com/google/uuid"
 )
 
 // URL on the controller where the metrics are exported in the Prometheus format.
@@ -113,8 +112,7 @@ func runNannyServer(ctx context.Context, server *http.Server, lis net.Listener) 
 }
 
 // RunController creates and runs a controller.
-func RunController(ctx context.Context, region string, port int) error {
-	id := uuid.New().String()
+func RunController(ctx context.Context, id string, region string, port int) error {
 	logger, close, err := makeNannyLogger(id, "controller")
 	if err != nil {
 		return err
@@ -183,8 +181,7 @@ func RunController(ctx context.Context, region string, port int) error {
 }
 
 // RunDistributor creates and runs a distributor.
-func RunDistributor(ctx context.Context, region string, port, managerPort int) error {
-	id := uuid.New().String()
+func RunDistributor(ctx context.Context, id, region string, port, managerPort int) error {
 	name := "distributor-" + region
 	logger, close, err := makeNannyLogger(id, name)
 	if err != nil {
@@ -266,8 +263,7 @@ func RunDistributor(ctx context.Context, region string, port, managerPort int) e
 }
 
 // RunManager creates and runs a manager.
-func RunManager(ctx context.Context, region string, port, proxyPort int) error {
-	id := uuid.New().String()
+func RunManager(ctx context.Context, id, region string, port, proxyPort int) error {
 	name := "manager-" + region
 	logger, close, err := makeNannyLogger(id, name)
 	if err != nil {
@@ -353,8 +349,7 @@ func RunManager(ctx context.Context, region string, port, proxyPort int) error {
 }
 
 // RunProxy creates and runs a proxy listening on ":port".
-func RunProxy(ctx context.Context, port int) error {
-	id := uuid.New()
+func RunProxy(ctx context.Context, id string, port int) error {
 	ls, err := logging.NewFileStore(LogDir)
 	if err != nil {
 		return fmt.Errorf("cannot create log storage: %w", err)
@@ -363,9 +358,9 @@ func RunProxy(ctx context.Context, port int) error {
 	logger := slog.New(&logging.LogHandler{
 		Opts: logging.Options{
 			App:        "nanny",
-			Deployment: id.String(),
+			Deployment: id,
 			Component:  "proxy",
-			Weavelet:   id.String(),
+			Weavelet:   id,
 			Attrs:      []string{"serviceweaver/system", ""},
 		},
 		Write: ls.Add,


### PR DESCRIPTION
Previously the sub-processes created for the GKE local deployment would discard stdout and stderr messages. This made it really hard to debug problems (e.g., panic messages would get lost). We now capture lines written to stdout and stderr by these sub-processes and write them to log storage.

Removed a stray "LogBatch" stderr message from a previous change.

Example output after killing a controller process by hand:

```
Tailing the logs...
S1004 13:05:55.316463 stdout               d9a66407                      │ echo listener available on http://localhost:8000
S1004 13:05:55.326168 stdout               3826452b                      │ echo listener available on http://localhost:8000
S1004 13:06:13.219034 controller.stdout    65f17a29                      │ sub-process read error err="EOF"
S1004 13:06:13.219144 controller.stderr    65f17a29                      │ sub-process read error err="EOF"
```