### PR TITLE
Use Go 1.21 when building the tool image inside the container.

### DIFF
--- a/internal/gke/build.go
+++ b/internal/gke/build.go
@@ -29,7 +29,7 @@ import (
 
 var dockerfileTmpl = template.Must(template.New("Dockerfile").Parse(`
 {{if .GoInstall}}
-FROM golang:1.20-bullseye as builder
+FROM golang:1.21-bullseye as builder
 RUN echo ""{{range .GoInstall}} && go install {{.}}{{end}}
 {{end}}
 FROM ubuntu:rolling


### PR DESCRIPTION
This is required as we no longer support Go 1.20.