### PR TITLE
Don't create special config cluster.

### DIFF
--- a/cmd/weaver-gke/store.go
+++ b/cmd/weaver-gke/store.go
@@ -26,18 +26,20 @@ import (
 )
 
 var (
-	storeFlags  = newCloudFlagSet("store", flag.ContinueOnError)
-	storeRegion = storeFlags.String("region", gke.ConfigClusterRegion,
-		`Cloud region where the store resides. Default value is the region of
-the Service Weaver configuration cluster.`)
-	storeCluster = storeFlags.String("cluster", gke.ConfigClusterName,
-		`GKE cluster where the store resides. Default value is the name of the
-Service Weaver configuration cluster.`)
-
-	storeSpec = tool.StoreSpec{
+	storeFlags   = newCloudFlagSet("store", flag.ContinueOnError)
+	storeRegion  = storeFlags.String("region", "", `Cloud region where the store resides.`)
+	storeCluster = storeFlags.String("cluster", "", `GKE cluster where the store resides.`)
+	storeSpec    = tool.StoreSpec{
 		Tool:  "weaver gke",
 		Flags: storeFlags.FlagSet,
 		Store: func(ctx context.Context) (store.Store, error) {
+			if *storeRegion == "" {
+				return nil, fmt.Errorf("must specify --region flag")
+			}
+			if *storeCluster == "" {
+				return nil, fmt.Errorf("must specify --cluster flag. Note that" +
+					"the cluster should be either serviceweaver or serviceweaver-config")
+			}
 			config, err := storeFlags.CloudConfig()
 			if err != nil {
 				return nil, err

--- a/internal/gke/cluster_info.go
+++ b/internal/gke/cluster_info.go
@@ -82,7 +82,7 @@ type ClusterInfo struct {
 func GetClusterInfo(ctx context.Context, config CloudConfig, cluster, region string) (*ClusterInfo, error) {
 	// Fetch cluster credentials to the local machine.
 	kubeFileName := filepath.Join(
-		os.TempDir(), fmt.Sprintf("serviceweaver_%s_%s", cluster, uuid.New().String()))
+		os.TempDir(), fmt.Sprintf("serviceweaver_%s", uuid.New().String()))
 	if _, err := runGcloud(config, "", cmdOptions{
 		EnvOverrides: []string{
 			fmt.Sprintf("KUBECONFIG=%s", kubeFileName),
@@ -137,7 +137,7 @@ func isZone(location string) bool {
 	return strings.Count(location, "-") > 1
 }
 
-func fillClusterInfo(ctx context.Context, cluster, region string, cc CloudConfig, kc *rest.Config) (*ClusterInfo, error) {
+func fillClusterInfo(_ context.Context, cluster, region string, cc CloudConfig, kc *rest.Config) (*ClusterInfo, error) {
 	// Avoid Kubernetes' low default QPS limit.
 	kc.QPS = math.MaxInt
 	kc.Burst = math.MaxInt

--- a/internal/gke/gke.go
+++ b/internal/gke/gke.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math"
 	"net"
 	"os"
@@ -27,8 +28,6 @@ import (
 	"strings"
 	"text/template"
 	"time"
-
-	"log/slog"
 
 	"cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/ServiceWeaver/weaver-gke/internal/config"
@@ -69,12 +68,6 @@ const (
 
 	// Name of Service Weaver application clusters.
 	applicationClusterName = "serviceweaver"
-
-	// Name of a Service Weaver configuration cluster.
-	ConfigClusterName = "serviceweaver-config"
-
-	// Region for the Service Weaver configuration cluster.
-	ConfigClusterRegion = "us-central1"
 
 	// Name of the backend config used for configuring application listener
 	// backends.

--- a/internal/gke/logging.go
+++ b/internal/gke/logging.go
@@ -138,7 +138,6 @@ func newGCPCatter(ctx context.Context, config CloudConfig, q wlogging.Query) (*g
 	if err != nil {
 		return nil, fmt.Errorf("error translating query %s: %v", q, err)
 	}
-
 	client, err := logadmin.NewClient(ctx, config.Project, config.ClientOptions()...)
 	if err != nil {
 		return nil, fmt.Errorf("error creating logadmin client: %w", err)
@@ -412,7 +411,8 @@ func Translate(project string, query wlogging.Query) (string, error) {
 	// TODO(mwhittaker): Restrict based on location.
 	fmt.Fprintf(&b, ` AND resource.type="k8s_container"`)
 	fmt.Fprintf(&b, ` AND resource.labels.project_id=%q`, project)
-	fmt.Fprintf(&b, ` AND (resource.labels.cluster_name=%q OR resource.labels.cluster_name=%q)`, applicationClusterName, ConfigClusterName)
+	fmt.Fprintf(&b, ` AND (resource.labels.cluster_name=%q OR resource.labels.cluster_name=%q)`,
+		applicationClusterName, fmt.Sprintf("%s-config", applicationClusterName))
 	fmt.Fprintf(&b, ` AND resource.labels.namespace_name=%q`, namespaceName)
 	fmt.Fprintf(&b, ` AND (resource.labels.container_name=%q OR resource.labels.container_name=%q)`, appContainerName, nannyContainerName)
 	fmt.Fprintf(&b, ` AND logName="projects/%s/logs/serviceweaver"`, project)

--- a/internal/gke/nanny.go
+++ b/internal/gke/nanny.go
@@ -125,7 +125,12 @@ func runNannyServer(ctx context.Context, server *http.Server, lis net.Listener) 
 // Controller returns the HTTP address of the controller and an HTTP client
 // that can be used to contact the controller.
 func Controller(ctx context.Context, config CloudConfig) (string, *http.Client, error) {
-	configCluster, err := GetClusterInfo(ctx, config, ConfigClusterName, ConfigClusterRegion)
+	name, region, err := getRunningConfigCluster(config)
+	if err != nil || region == "" {
+		return "", nil, err
+	}
+
+	configCluster, err := GetClusterInfo(ctx, config, name, region)
 	if err != nil {
 		return "", nil, err
 	}

--- a/internal/gke/purge.go
+++ b/internal/gke/purge.go
@@ -213,14 +213,18 @@ func deleteRepository(ctx context.Context, config CloudConfig) (func() error, er
 
 // deleteConfigCluster deletes the Service Weaver configuration cluster.
 func deleteConfigCluster(ctx context.Context, config CloudConfig) (func() error, error) {
-	exists, err := hasCluster(ctx, config, ConfigClusterName, ConfigClusterRegion)
+	name, region, err := getRunningConfigCluster(config)
+	if err != nil || region == "" { // already deleted
+		return nil, nil
+	}
+	exists, err := hasCluster(ctx, config, name, region)
 	if err != nil {
 		return nil, err
 	}
 	if !exists { // already deleted
 		return nil, nil
 	}
-	return deleteCluster(ctx, config, ConfigClusterName, ConfigClusterRegion)
+	return deleteCluster(ctx, config, name, region)
 }
 
 // getApplicationClusters returns the list of Service Weaver application clusters.

--- a/internal/tool/deploy.go
+++ b/internal/tool/deploy.go
@@ -148,6 +148,9 @@ func makeGKEConfig(app *protos.AppConfig) (*config.GKEConfig, error) {
 			listeners[lis] = &config.GKEConfig_ListenerOptions{PublicHostname: opts.PublicHostname}
 		}
 	}
+	if err := validateDeployRegions(parsed.Regions); err != nil {
+		return nil, err
+	}
 
 	depID := uuid.New()
 	cfg := &config.GKEConfig{
@@ -192,7 +195,7 @@ func (d *DeploySpec) doDeploy(ctx context.Context, cfg *config.GKEConfig) error 
 	}
 	if versions.DeployerVersion != version.DeployerVersion {
 		// Try to relativize the binary, defaulting to the absolute path if
-		// there are any errors..
+		// there are any errors.
 		binary := app.Binary
 		if cwd, err := os.Getwd(); err == nil {
 			if rel, err := filepath.Rel(cwd, app.Binary); err == nil {
@@ -276,10 +279,6 @@ persists, please file an issue at https://github.com/ServiceWeaver/weaver/issues
 
 // startRollout starts the rollout of the given application version.
 func (d *DeploySpec) startRollout(ctx context.Context, cfg *config.GKEConfig) error {
-	if err := pickDeployRegions(cfg); err != nil {
-		return err
-	}
-
 	req, err := d.PrepareRollout(ctx, cfg)
 	if err != nil {
 		return err
@@ -310,22 +309,20 @@ func (d *DeploySpec) startRollout(ctx context.Context, cfg *config.GKEConfig) er
 	return fmt.Errorf("timeout trying to deploy the app; last error: %w", err)
 }
 
-// pickDeployRegions ensures that the application config has a valid set of
+// validateDeployRegions ensures that the application config has a valid set of
 // unique regions to deploy the application. If the app config doesn't specify
 // any regions where to deploy the app, we pick the regions.
 //
-// TODO(rgrandl): We pick "us-west1" as the default region. However, we should
-// determine the set of regions to deploy the app based on various constraints
-// (e.g., traffic patterns, geographical location, etc.).
-func pickDeployRegions(cfg *config.GKEConfig) error {
-	if len(cfg.Regions) == 0 {
-		cfg.Regions = []string{"us-west1"}
-		return nil
+// Note that at least one region should be specified.
+func validateDeployRegions(regions []string) error {
+	// Ensure that at least one deployment region is specified.
+	if len(regions) == 0 {
+		return fmt.Errorf("no regions where the app should be deployed were specified")
 	}
 
 	// Ensure that the set of regions is unique.
-	unique := make(map[string]bool, len(cfg.Regions))
-	for _, elem := range cfg.Regions {
+	unique := make(map[string]bool, len(regions))
+	for _, elem := range regions {
 		if unique[elem] {
 			return fmt.Errorf("the set of regions should be unique; found %s "+
 				"multiple times", elem)

--- a/internal/tool/deploy_test.go
+++ b/internal/tool/deploy_test.go
@@ -44,25 +44,29 @@ func TestMakeGKEConfig(t *testing.T) {
 	}
 	for _, c := range []testCase{
 		{
-			name:   "empty",
-			config: ``,
-			expect: &config.GKEConfig{},
+			name: "basic",
+			config: `
+[gke]
+regions = ["us-central1"]`,
+			expect: &config.GKEConfig{Regions: []string{"us-central1"}},
 		},
 		{
 			name: "simple",
 			config: `
 [gke]
 mtls = true
+regions = ["us-central1"]
 `,
-			expect: &config.GKEConfig{Mtls: true},
+			expect: &config.GKEConfig{Mtls: true, Regions: []string{"us-central1"}},
 		},
 		{
 			name: "long-key",
 			config: `
 ["github.com/ServiceWeaver/weaver-gke/internal/gke"]
 mtls = true
+regions = ["us-central1"]
 `,
-			expect: &config.GKEConfig{Mtls: true},
+			expect: &config.GKEConfig{Mtls: true, Regions: []string{"us-central1"}},
 		},
 		{
 			name: "listeners",
@@ -70,12 +74,14 @@ mtls = true
 [gke]
 listeners.a = {public_hostname="a.com"}
 listeners.b = {public_hostname="b.com"}
+regions = ["us-central1"]
 `,
 			expect: &config.GKEConfig{
 				Listeners: map[string]*config.GKEConfig_ListenerOptions{
 					"a": {PublicHostname: "a.com"},
 					"b": {PublicHostname: "b.com"},
 				},
+				Regions: []string{"us-central1"},
 			},
 		},
 	} {


### PR DESCRIPTION
In the current implementation, the GKE deployer creates a cluster for each region where the application is being deployed. Also, it creates a config cluster in "us-central1" where the controller is being deployed.

This is not great, because for each user project, we create an additional cluster which translates into cloud costs for the user.

This PR deploys the controller in one of the clusters where applications that are part of the same user project are being deployer.

If this is the first time the user deploys an app in their project, the controller is deployed in the first region where the app is being deployed. However, if the controller is already running in some cluster, it will run there forever.

The caveat with this approach is that if the user decides some day to not deploy anything anymore in the region where the controller has been running, we'll still run the controller in that region.