### PR TITLE
[GKE] Enable to deploy in a different project

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -82,7 +82,7 @@ jobs:
       # TODO(spetrovic): use the hostname directly once we change the DNS
       # records to point to the IP address below.
       run: |
-        timeout ${{ env.WAIT_TIMEOUT }} /bin/sh -c 'while true; do wget -O- -T 10 --header "Host: echo.serviceweaver.dev" http://34.36.161.250:80?s=${{env.VERSION}} && break; sleep 15; done'
+        timeout ${{ env.WAIT_TIMEOUT }} /bin/sh -c 'while true; do wget -O- -T 10 --header "Host: echo.serviceweaver.dev" http://34.36.173.102:80?s=${{env.VERSION}} && break; sleep 15; done'
 
     - name: Cleanup the echo app
       if: always()

--- a/internal/gke/cloud_config.go
+++ b/internal/gke/cloud_config.go
@@ -115,7 +115,7 @@ func SetupCloudConfig(project, token, account string) (CloudConfig, error) {
 
 	number, err := runGcloud(
 		config, "", cmdOptions{}, "projects", "describe", project,
-		"--format=value(projectNumber)", "--project", project)
+		"--format=value(projectNumber)")
 	if err != nil {
 		return CloudConfig{}, fmt.Errorf("couldn't find the numeric project "+
 			"id for project %q: %w", project, err)

--- a/internal/gke/cmd.go
+++ b/internal/gke/cmd.go
@@ -36,6 +36,10 @@ func runGcloud(config CloudConfig, msg string, opts cmdOptions, args ...string) 
 		return "", fmt.Errorf("cannot get cloud access token: %w", err)
 	}
 	opts.EnvOverrides = append(opts.EnvOverrides, fmt.Sprintf("CLOUDSDK_AUTH_ACCESS_TOKEN=%s", token.AccessToken))
+	args = append(args,
+		fmt.Sprintf("--account=%s", config.Account),
+		fmt.Sprintf("--project=%s", config.Project),
+	)
 	return runCmd(msg, opts, "gcloud", args...)
 }
 


### PR DESCRIPTION
Users may want to deploy apps in different cloud projects than the one they are currently logged in (gcloud init). The current GKE implementation has a bug that prevents them to do this. Most of the gcloud commands don't take a `--project` and an `--account` argument, and the gcloud command will consider the project and the account values as the ones set in the current project.

E.g.,
Current project is `psyched-zone-398223`, and I tried to deploy an app in the project `dingo-gke-dev`. This is what the current GKE deployer does:

`
rgrandl@:~/projects/weaver_wip/weaver-gke$ ./cmd/weaver-gke/weaver-gke deploy --project="dingo-gke-dev" ../weaver/examples/collatz/weaver.toml Deploying to project dingo-gke-dev
Starting the application container build us-docker.pkg.dev/dingo-gke-dev/serviceweaver-repo/app:tagd4206700 Stopping with error: Fetching cluster endpoint and auth data. ERROR: (gcloud.container.clusters.get-credentials) ResponseError: code=404, message=Not found: projects/psyched-zone-398223/locations/us-central1/clusters/serviceweaver-config. No cluster named 'serviceweaver-config' in psyched-zone-398223. `

This is because the project `psyched-zone-398223` doesn't have a serviceweaver-config cluster. This shouldn't matter, because we were trying to deploy in `dingo-gke-dev` which has a service-weaver config cluster.

Even if we create a serviceweaver-config cluster in `psyched-zone-398223`, and rerun the command, we got the following:

`
rgrandl@:~/projects/weaver_wip/weaver-gke$ ./cmd/weaver-gke/weaver-gke deploy --project="dingo-gke-dev" ../weaver/examples/collatz/weaver.toml Deploying to project dingo-gke-dev
Starting the application container build us-docker.pkg.dev/dingo-gke-dev/serviceweaver-repo/app:tag0819da10 Updating workload certificate config "default" in cluster serviceweaver-config in region us-central1... Done Updating trust config "default" in cluster serviceweaver-config in region us-central1... Stopping with error: admission webhook "trustconfig-admission-controller.spiffe.gke.io" denied the request: .spec.trustStores must specify configuration for the local trust domain (i.e., "psyched-zone-398223.svc.id.goog") `

It somehow tries to update the config in the `psyched-zone-398223` project again.

The fix is to pass the `--project` and the `--account` arguments to the gcloud command.