### PR TITLE
Purge the deprecated config cluster

### DIFF
--- a/internal/gke/deploy.go
+++ b/internal/gke/deploy.go
@@ -1013,9 +1013,9 @@ func getRunningConfigCluster(config CloudConfig) (string, string, error) {
 	// cluster should be running.
 	out = strings.TrimSuffix(out, "\n") // remove trailing newline
 	var clusterName, region string
-	if strings.Contains(out, "serviceweaver-config") {
+	if strings.Contains(out, deprecatedConfigClusterName) {
 		// Legacy config cluster name.
-		clusterName = "serviceweaver-config"
+		clusterName = deprecatedConfigClusterName
 	} else if strings.Contains(out, applicationClusterName) {
 		// New config clusters should always be named applicationClusterName.
 		clusterName = applicationClusterName

--- a/internal/gke/gke.go
+++ b/internal/gke/gke.go
@@ -69,6 +69,9 @@ const (
 	// Name of Service Weaver application clusters.
 	applicationClusterName = "serviceweaver"
 
+	// Name of the deprecated Service Weaver config cluster.
+	deprecatedConfigClusterName = "serviceweaver-config"
+
 	// Name of the backend config used for configuring application listener
 	// backends.
 	backendConfigName = "serviceweaver"


### PR DESCRIPTION
We changed the way we deploy the Service Weaver config cluster; i.e., we deploy the controller in one of the application clusters instead.

However, for old deployments, the user might still have the config cluster (that runs in us-central1) around.

This PR updates the purge command to delete the us-central1 config cluster as well (if exists).