### PR TITLE
Memory leak fix

### DIFF
--- a/internal/gke/babysitter.go
+++ b/internal/gke/babysitter.go
@@ -142,9 +142,11 @@ func RunBabysitter(ctx context.Context) error {
 		return err
 	}
 
+	// Create an unique http client to the manager, that will be reused across all
+	// the http requests to the manager.
 	m := &manager.HttpClient{
-		Addr:      cfg.ManagerAddr,
-		TLSConfig: mtls.ClientTLSConfig(meta.Project, caCert, getSelfCert, "manager"),
+		Addr:   cfg.ManagerAddr,
+		Client: makeHttpClient(mtls.ClientTLSConfig(meta.Project, caCert, getSelfCert, "manager")),
 	}
 	mux := http.NewServeMux()
 	host, err := os.Hostname()

--- a/internal/local/babysitter.go
+++ b/internal/local/babysitter.go
@@ -102,8 +102,8 @@ func startBabysitter(ctx context.Context, cfg *config.GKEConfig, s *Starter, rep
 
 	// Connection to the manager.
 	m := &manager.HttpClient{
-		Addr:      cfg.ManagerAddr,
-		TLSConfig: mtls.ClientTLSConfig(projectName, caCert, getSelfCert, "manager"),
+		Addr:   cfg.ManagerAddr,
+		Client: makeHttpClient(mtls.ClientTLSConfig(projectName, caCert, getSelfCert, "manager")),
 	}
 	mux := http.NewServeMux()
 	hostname, err := os.Hostname()

--- a/internal/nanny/manager/client.go
+++ b/internal/nanny/manager/client.go
@@ -16,7 +16,6 @@ package manager
 
 import (
 	"context"
-	"crypto/tls"
 	"net/http"
 
 	"github.com/ServiceWeaver/weaver-gke/internal/endpoints"
@@ -27,30 +26,18 @@ import (
 
 // HttpClient is a Client that executes requests over HTTP.
 type HttpClient struct {
-	Addr      string      // manager address
-	TLSConfig *tls.Config // TLS config, possibly nil.
+	Addr   string       // manager address
+	Client *http.Client // The HTTP client to use to make requests.
 }
 
 var (
 	_ endpoints.Manager = &HttpClient{}
 )
 
-// client returns the HTTP client to use to make requests.
-func (h *HttpClient) client() *http.Client {
-	if h.TLSConfig == nil {
-		return http.DefaultClient
-	}
-	return &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: h.TLSConfig,
-		},
-	}
-}
-
 // Deploy implements the endpoints.Manager interface.
 func (h *HttpClient) Deploy(ctx context.Context, req *nanny.ApplicationDeploymentRequest) error {
 	return protomsg.Call(ctx, protomsg.CallArgs{
-		Client:  h.client(),
+		Client:  h.Client,
 		Addr:    h.Addr,
 		URLPath: deployURL,
 		Request: req,
@@ -60,7 +47,7 @@ func (h *HttpClient) Deploy(ctx context.Context, req *nanny.ApplicationDeploymen
 // Stop implements the endpoints.Manager interface.
 func (h *HttpClient) Stop(ctx context.Context, req *nanny.ApplicationStopRequest) error {
 	return protomsg.Call(ctx, protomsg.CallArgs{
-		Client:  h.client(),
+		Client:  h.Client,
 		Addr:    h.Addr,
 		URLPath: stopURL,
 		Request: req,
@@ -70,7 +57,7 @@ func (h *HttpClient) Stop(ctx context.Context, req *nanny.ApplicationStopRequest
 // Delete implements the endpoints.Manager interface.
 func (h *HttpClient) Delete(ctx context.Context, req *nanny.ApplicationDeleteRequest) error {
 	return protomsg.Call(ctx, protomsg.CallArgs{
-		Client:  h.client(),
+		Client:  h.Client,
 		Addr:    h.Addr,
 		URLPath: deleteURL,
 		Request: req,
@@ -81,7 +68,7 @@ func (h *HttpClient) Delete(ctx context.Context, req *nanny.ApplicationDeleteReq
 func (h *HttpClient) GetReplicaSets(ctx context.Context, req *nanny.GetReplicaSetsRequest) (*nanny.GetReplicaSetsReply, error) {
 	reply := &nanny.GetReplicaSetsReply{}
 	err := protomsg.Call(ctx, protomsg.CallArgs{
-		Client:  h.client(),
+		Client:  h.Client,
 		Addr:    h.Addr,
 		URLPath: getReplicaSetsURL,
 		Request: req,
@@ -93,7 +80,7 @@ func (h *HttpClient) GetReplicaSets(ctx context.Context, req *nanny.GetReplicaSe
 // ActivateComponent implements the endpoints.Manager interface.
 func (h *HttpClient) ActivateComponent(ctx context.Context, req *nanny.ActivateComponentRequest) error {
 	return protomsg.Call(ctx, protomsg.CallArgs{
-		Client:  h.client(),
+		Client:  h.Client,
 		Addr:    h.Addr,
 		URLPath: activateComponentURL,
 		Request: req,
@@ -104,7 +91,7 @@ func (h *HttpClient) ActivateComponent(ctx context.Context, req *nanny.ActivateC
 func (h *HttpClient) GetListenerAddress(ctx context.Context, req *nanny.GetListenerAddressRequest) (*protos.GetListenerAddressReply, error) {
 	reply := &protos.GetListenerAddressReply{}
 	if err := protomsg.Call(ctx, protomsg.CallArgs{
-		Client:  h.client(),
+		Client:  h.Client,
 		Addr:    h.Addr,
 		URLPath: getListenerAddressURL,
 		Request: req,
@@ -119,7 +106,7 @@ func (h *HttpClient) GetListenerAddress(ctx context.Context, req *nanny.GetListe
 func (h *HttpClient) ExportListener(ctx context.Context, req *nanny.ExportListenerRequest) (*protos.ExportListenerReply, error) {
 	reply := &protos.ExportListenerReply{}
 	if err := protomsg.Call(ctx, protomsg.CallArgs{
-		Client:  h.client(),
+		Client:  h.Client,
 		Addr:    h.Addr,
 		URLPath: exportListenerURL,
 		Request: req,
@@ -134,7 +121,7 @@ func (h *HttpClient) ExportListener(ctx context.Context, req *nanny.ExportListen
 func (h *HttpClient) GetRoutingInfo(ctx context.Context, req *nanny.GetRoutingRequest) (*nanny.GetRoutingReply, error) {
 	reply := &nanny.GetRoutingReply{}
 	if err := protomsg.Call(ctx, protomsg.CallArgs{
-		Client:  h.client(),
+		Client:  h.Client,
 		Addr:    h.Addr,
 		URLPath: getRoutingInfoURL,
 		Request: req,
@@ -150,7 +137,7 @@ func (h *HttpClient) GetComponentsToStart(ctx context.Context, req *nanny.GetCom
 	*nanny.GetComponentsReply, error) {
 	reply := &nanny.GetComponentsReply{}
 	if err := protomsg.Call(ctx, protomsg.CallArgs{
-		Client:  h.client(),
+		Client:  h.Client,
 		Addr:    h.Addr,
 		URLPath: getComponentsToStartURL,
 		Request: req,


### PR DESCRIPTION
One of our customers observed that we have a memory leak in our services. Looking at the memory usage for the controller, distributor, manager we could see how the memory spikes above the requested limit, and then the pods will eventually restart. 

We did profile the controller, distributor, manager and we observed that large chunk of the allocated heap has been due to TLS stuff which seems to be an indication that we may not create http connections properly. 

Our HTTP clients when using TLS have disable keep alive (which means the underlying http connections should be reused). We looked at the number of new, idle, and closed connections over time for each service, and we found out that we kept creating new connections instead of reusing them. 

We tried many things, but one thing that we were doing wrong, and it was the actual issue, is that we were creating new http clients for every request when using TLS.

